### PR TITLE
Fix submodule in modern manner

### DIFF
--- a/src/suffix_tree.rs
+++ b/src/suffix_tree.rs
@@ -1,3 +1,2 @@
 pub mod suffix_tree;
 pub mod ukkonnen_vec_lib;
-// pub mod suffix_tree;


### PR DESCRIPTION
Using `mod.rs` is an old manner to declare submodules

- cf. https://keens.github.io/blog/2018/12/08/rustnomoju_runotsukaikata_2018_editionhan/

This PR fixes the declaration.